### PR TITLE
feat: migrate to Keycloak quarkus

### DIFF
--- a/java/blockchain-connector/pom.xml
+++ b/java/blockchain-connector/pom.xml
@@ -22,6 +22,21 @@
             <version>4.9.3</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>4.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.8.2</version>

--- a/java/keycloak-extensions/Dockerfile
+++ b/java/keycloak-extensions/Dockerfile
@@ -1,3 +1,14 @@
-FROM  quay.io/keycloak/keycloak:legacy
+ARG KEYCLOAK_VERSION=18.0.2
 
-ADD target/keyblock-extensions*.jar /opt/jboss/keycloak/standalone/deployments
+# See https://www.keycloak.org/server/containers
+FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} as builder
+
+# Install custom providers
+ADD target/keyblock-extensions*.jar /opt/keycloak/providers
+
+# quarkus needs build with custom extensions
+RUN /opt/keycloak/bin/kc.sh build
+
+FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+WORKDIR /opt/keycloak

--- a/java/keycloak-extensions/docker-compose.yml
+++ b/java/keycloak-extensions/docker-compose.yml
@@ -6,13 +6,20 @@ services:
       build:
         context: .
         dockerfile: Dockerfile
+        args:
+          KEYCLOAK_VERSION: 18.0.2
       volumes:
-        - ./keyblock-realm-export.json:/tmp/keyblock-realm-export.json
+        - ./keyblock-realm-export.json:/opt/keycloak/data/import/keyblock-realm-export.json
+      command:
+        - "start-dev"
+        - "--http-enabled=true"
+        - "--http-port=8080"
+        - "--import-realm"
       environment:
         DEBUG: "true"
         DEBUG_PORT: "*:8787"
-        KEYCLOAK_USER: admin
-        KEYCLOAK_PASSWORD: password
+        KEYCLOAK_ADMIN: admin
+        KEYCLOAK_ADMIN_PASSWORD: password
         KEYCLOAK_IMPORT: /tmp/keyblock-realm-export.json
       ports:
         - "8580:8080"


### PR DESCRIPTION
not possible to migrate due to a conflict with okhttp used both by web3 and keycloak in two different versions : 
<img width="950" alt="image" src="https://user-images.githubusercontent.com/5501911/180455399-cfa24788-a923-4ea5-83bd-e8fe17df618c.png">

This is no workaround for now because the okhttp lib is embed in the Keycloak Quarkus distribution